### PR TITLE
Fix page ordering by exposing weight

### DIFF
--- a/src/api-clients/compose.ts
+++ b/src/api-clients/compose.ts
@@ -426,6 +426,7 @@ export default class Compose {
       title,
       handle,
       description,
+      weight,
       visible,
       blocks,
     } = (a as KV) || {}
@@ -453,6 +454,7 @@ export default class Compose {
       title,
       handle,
       description,
+      weight,
       visible,
       blocks,
     }

--- a/src/compose/types/page.ts
+++ b/src/compose/types/page.ts
@@ -21,6 +21,7 @@ export class Page {
   public title = '';
   public handle = '';
   public description = '';
+  public weight = 0;
 
   public visible = false;
 
@@ -49,6 +50,7 @@ export class Page {
 
     Apply(this, i, CortezaID, 'pageID', 'selfID', 'moduleID', 'namespaceID')
     Apply(this, i, String, 'title', 'handle', 'description')
+    Apply(this, i, Number, 'weight')
     Apply(this, i, Boolean, 'visible')
 
     if (i.blocks) {


### PR DESCRIPTION
Fix page order preservation by exposing the page's weight property.
This is required since the order is 0-based.