### PR TITLE
Remove precision from number formatting

### DIFF
--- a/src/compose/types/module-field/number.ts
+++ b/src/compose/types/module-field/number.ts
@@ -52,12 +52,9 @@ export class ModuleFieldNumber extends ModuleField {
         n = 0
     }
 
-    const p = o.precision < 0 || o.precision > 6 ? 0 : o.precision
-
-    let out = n.toFixed(p)
-
+    let out = `${n}`
     if (o.format && o.format.length > 0) {
-      out = numeral(out).format(o.format)
+      out = numeral(n).format(o.format)
     }
 
     return '' + o.prefix + out + o.suffix


### PR DESCRIPTION
This removes number precision when evaluating the formatted number to show on the UI.

@darh numeral's format currently rounds the value; so for example `numeral(11.5).format('0')` evaluates to `12`. Do we agree to keep this behavior?