### PR TITLE
Add support for metric post-proc functions

### DIFF
--- a/src/compose/types/chart/util.ts
+++ b/src/compose/types/chart/util.ts
@@ -33,6 +33,7 @@ export interface Metric {
   alias?: string;
   aggregate?: string;
   modifier?: string;
+  fx?: string;
   [_: string]: unknown;
 }
 


### PR DESCRIPTION
This allows us to perform simpler operations on end data, such as creating cumulative charts.

REF: https://github.com/cortezaproject/corteza-webapp-compose/pull/182